### PR TITLE
0.9.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean:
 	rm -rf test-install-venv/ local-install-venv/ prod-install-venv
 	rm -rf venv/ .venv/
 	rm -f *.whl.metadata .??*~
-	rm -rf .pytest_cache/ .ruff_cache/
+	rm -rf .coverage .pytest_cache/ .ruff_cache/
 	find . -type d -name "__pycache__" -exec rm -r "{}" +
 	find . -type f -name "*.pyc" -delete
 	command pip cache purge

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ pip install .
 For development installation:
 
 ```bash
-pip install -e '.[dev]'
+uv venv
+source .venv/bin/activate
+uv pip install -e '.[dev]'
+uv pip list
 ```
 
 ### Command Line Usage
@@ -72,7 +75,7 @@ pyfileversioning create myfile.txt
 
 Create a compressed version:
 ```bash
-pyfileversioning create myfile.txt -c gzip  # or --compression gzip
+pyfileversioning create myfile.txt -c gz  # or --compression gz
 ```
 
 List all versions:
@@ -109,7 +112,7 @@ Created version: backups/config--20240120.143022_001.ini
 $ echo "database_port=5432" >> config.ini
 
 # Create compressed version
-$ pyfileversioning create config.ini -d backups -c gzip  # Using short options
+$ pyfileversioning create config.ini -d backups -c gz  # Using short options
 Created version: backups/config--20240120.143156_001.ini.gz
 
 # List all versions
@@ -122,7 +125,7 @@ config--20240120.143022_001.ini              187 bytes  2024-01-20 14:30:22
 # Add more content and create another version
 $ echo "database_name=myapp" >> config.ini
 
-$ pyfileversioning create config.ini --versions-dir backups --compression gzip
+$ pyfileversioning create config.ini --versions-dir backups --compression gz
 Created version: backups/config--20240120.143312_001.ini.gz
 
 # View all versions with size and timestamp
@@ -142,7 +145,7 @@ $ cat config.ini.restored
 database_host=localhost
 
 # Clean up old versions (only keep the last 2)
-$ pyfileversioning create config.ini -d backups -c gzip -m 2  # Using short options
+$ pyfileversioning create config.ini -d backups -c gz -m 2  # Using short options
 Created version: backups/config--20240120.143428_001.ini.gz
 
 # Check that only 2 versions remain
@@ -199,7 +202,7 @@ version_path = versioning.create_version(TEST_FILE)
 
 ```
 usage: pyfileversioning [-h] [-V] [-t TARGET] [-d VERSIONS_DIR]
-                [-c {none,gzip,bz2,xz}] [-m MAX_VERSIONS]
+                [-c {none,gz,bz2,xz}] [-m MAX_VERSIONS]
                 [--timestamp-source {modified,now}]
                 {create,restore,list,remove} file
 ```
@@ -208,7 +211,7 @@ Options:
 * `-V, --version`: Show version information
 * `-t, --target`: Target path for restore
 * `-d, --versions-dir`: Directory to store versions (default: versions)
-* `-c, --compression`: Compression type to use (choices: none, gzip, bz2, xz)
+* `-c, --compression`: Compression type to use (choices: none, gz, bz2, xz)
 * `-m, --max-versions`: Maximum number of versions to keep
 * `--timestamp-source`: Source for timestamps (choices: modified, now)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ Repository = "https://github.com/jftuga/py-file-versioning.git"
 Issues = "https://github.com/jftuga/py-file-versioning/issues"
 
 [project.scripts]
-pyfileversioning = "py_file_versioning.cli:main"
+pyfileversioning = "py_file_versioning.pyfileversioning:main"
 
 [tool.hatch.version]
 path = "src/py_file_versioning/__init__.py"

--- a/src/py_file_versioning/__init__.py
+++ b/src/py_file_versioning/__init__.py
@@ -10,7 +10,7 @@ from .file_versioning import (
     VersionInfo,
 )
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __all__ = [
     "FileVersioning",
     "FileVersioningConfig",

--- a/src/py_file_versioning/file_versioning.py
+++ b/src/py_file_versioning/file_versioning.py
@@ -17,7 +17,7 @@ class VersionError(Exception):
 
 class CompressionType(Enum):
     NONE = "none"
-    GZIP = "gzip"
+    GZIP = "gz"
     BZ2 = "bz2"
     XZ = "xz"
 
@@ -162,7 +162,7 @@ class FileVersioning:
     """A class for managing file versioning with configurable timestamps, compression, and cleanup.
 
     This class provides functionality to create, restore, and manage versioned copies of files
-    with support for different compression methods (gzip, bz2, xz), timestamp formats,
+    with support for different compression methods (gz, bz2, xz), timestamp formats,
     and automatic cleanup of old versions. Each version is stored with a timestamp
     and sequence number to maintain unique identifiers.
 
@@ -174,9 +174,9 @@ class FileVersioning:
     """
 
     MAX_SEQUENCE = 999
-    LIB_NAME = "pyfileversioning"
+    LIB_NAME = ""
     LIB_VERSION = ""
-    LIB_URL = "https://github.com/jftuga/py_file_versioning"
+    LIB_URL = ""
 
     def __init__(self, config: FileVersioningConfig = None):
         """Initialize the FileVersioning instance with the given configuration.
@@ -314,14 +314,14 @@ class FileVersioning:
             dest_path: Path where the compressed file should be saved.
         """
         compression_handlers = {
-            CompressionType.GZIP: gzip.open,
-            CompressionType.BZ2: bz2.open,
-            CompressionType.XZ: lzma.open,
+            CompressionType.GZIP: lambda path: gzip.open(path, "wb", compresslevel=9),
+            CompressionType.BZ2: lambda path: bz2.open(path, "wb", compresslevel=9),
+            CompressionType.XZ: lambda path: lzma.open(path, "wb", preset=9),
         }
 
         if self.config.compression in compression_handlers:
             with source_path.open("rb") as f_in:
-                with compression_handlers[self.config.compression](str(dest_path), "wb") as f_out:
+                with compression_handlers[self.config.compression](str(dest_path)) as f_out:
                     shutil.copyfileobj(f_in, f_out)
         else:
             shutil.copy2(str(source_path), str(dest_path))

--- a/src/py_file_versioning/pyfileversioning.py
+++ b/src/py_file_versioning/pyfileversioning.py
@@ -58,7 +58,7 @@ def main(args=None):
     parser.add_argument(
         "-c",
         "--compression",
-        choices=["none", "gzip", "bz2", "xz"],
+        choices=["none", "gz", "bz2", "xz"],
         default="none",
         help="Compression type to use",
     )

--- a/src/py_file_versioning/test_file_versioning.py
+++ b/src/py_file_versioning/test_file_versioning.py
@@ -36,8 +36,12 @@ def sample_file(temp_dir):
 
 @pytest.fixture
 def unicode_file(temp_dir):
-    """Create a sample file with Unicode name for testing."""
-    file_path = temp_dir / "????.txt"
+    """Create a sample file with Unicode name for testing.
+    This will render to tést_filê.txt.
+    * \u00e9 = é (lowercase e with acute accent)
+    * \u00ea = ê (lowercase e with circumflex)
+    """
+    file_path = temp_dir / "t\u00e9st_fil\u00ea.txt"
     with file_path.open("w") as f:
         f.write("Unicode test content")
     yield file_path
@@ -400,7 +404,7 @@ def test_list_versions(temp_dir, sample_file):
             "delimiter": "--",
             "expected": {"original_name": "test", "compression": CompressionType.NONE, "sequence": 1},
         },
-        # Test gzip compression
+        # Test gz compression
         {
             "filename": "test--20240101.120000_002.txt.gz",
             "delimiter": "--",

--- a/test_cli_integration.py
+++ b/test_cli_integration.py
@@ -45,7 +45,7 @@ def main():
         print(f"Original hash: {original_hash}")
 
         # Test different compression types
-        compression_types = ["none", "gzip", "bz2", "xz"]
+        compression_types = ["none", "gz", "bz2", "xz"]
         for compression in compression_types:
             print(f"\nTesting {compression} compression:")
             print("-" * 30)


### PR DESCRIPTION
* use maximum compression for `-c` option: gz, bz2, and xz
* use 'gz' instead of 'gzip' for `-c` option
* use a better unicode filename for testing
* don't hard code `LIB_NAME` and `LIB_URL` values in `file_versioning.py`
